### PR TITLE
encファイルの切り替えによりDB接続ができなくなってしまったためバグを修正 #74

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,4 +1,5 @@
 ENV_TYPE="dev"
+CONTAINER_NAME="mers-db-dev"
 MYSQL_ROOT_PASSWORD="root"
 MYSQL_DATABASE="mers-db-dev"
 MYSQL_USER="light"

--- a/.env.prod
+++ b/.env.prod
@@ -1,4 +1,5 @@
 ENV_TYPE="prod"
+CONTAINER_NAME="mers-db-prod"
 MYSQL_ROOT_PASSWORD="root"
 MYSQL_DATABASE="mers-db-prod"
 MYSQL_USER="light"

--- a/backend/internal/repository/db.go
+++ b/backend/internal/repository/db.go
@@ -2,7 +2,9 @@ package repository
 
 import (
 	"database/sql"
+	"fmt"
 	"log"
+	"os"
 
 	_ "github.com/go-sql-driver/mysql"
 )
@@ -15,12 +17,16 @@ func init() {
 }
 
 func openDB() {
-	db_name, err := sql.Open("mysql", "root:root@tcp(mers-db:3306)/mers-db?")
+	var err error
+	user := os.Getenv("MYSQL_USER")
+	password := os.Getenv("MYSQL_PASSWORD")
+	containerName := os.Getenv("CONTAINER_NAME")
+	dbName := os.Getenv("MYSQL_DATABASE")
+
+	db, err = sql.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:3306)/%s?", user, password, containerName, dbName))
 	if err != nil {
 		log.Fatalf("main sql.Open error err:%v", err)
 	}
-
-	db = db_name
 }
 
 func CloseDB() {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ services:
   frontend:
     container_name: mers-frontend
     build: ./frontend
-    environment:
-      - NODE_ENV=development
+    env_file:
+      - .env.${ENV_TYPE}
     tty: true
     stdin_open: true
     ports:
@@ -15,11 +15,14 @@ services:
   backend:
     container_name: api-server
     build: ./backend
+    env_file:
+      - .env.${ENV_TYPE}
+    tty: true
+    stdin_open: true
     ports:
       - 3000:3000
     volumes:
       - ./backend/internal:/go/src/backend/internal
-    tty: true
   database:
     image: mysql:8.0
     container_name: ${MYSQL_DATABASE}


### PR DESCRIPTION
## 概要
envファイルによる開発環境の切り替えを実装した際にdb接続ができないバグが発生しました．

## 原因
DB接続時のpathをハードコーディングしていたため，切り替えができないようになっていました．

## 修正内容
envファイルの環境変数を用いてpathを切り替えるように変更しました．
また，Goの`os.getenv`はデフォルトでは`.env`を参照するようになっているため，docker-compose.ymlのenv_fileを指定することで解決しました．
DB接続動作検証済みです．