### PR TITLE
Fixing go air version for backend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,6 +9,6 @@ ADD . /go/src/backend
 
 RUN go mod download
 
-RUN go install github.com/air-verse/air@latest
+RUN go install github.com/air-verse/air@v1.52.3
 
 CMD ["air", "-c", ".air.toml"]


### PR DESCRIPTION
Since version 1.60.0 air switched to golang v1.23 as specified in https://github.com/air-verse/air/releases/tag/v1.60.0

This change breaks commands `make build-up prod` and `make build-up dev`
Fixing air version to the previous stable release